### PR TITLE
Fix a tool-breaking bug, causing 0 SNPs to be reported.

### DIFF
--- a/2_create_GRS.R
+++ b/2_create_GRS.R
@@ -380,6 +380,7 @@ if(sum(ld$Trait.x==ld$Trait.y)>0){
 }
 if(!is.null(SNPLD)){
     outLD <- data.frame(SNP=SNPLD,trait=traitLD,stringsAsFactors=F)
+    outLD <- unique(outLD)
     for(out in 1:nrow(outLD)){
         final <- final[-which(final$Trait==outLD[out,'trait'] & final$ID==outLD[out,'SNP']),]
     }


### PR DESCRIPTION
**Problem**
This code is supposed to remove SNPs in LD, leaving one SNP from each cluster. It will occasionally break if the input data contain a lot of SNPs in the same LD cluster (bug might appear if 3 or more SNPs are in LD).

**The cause**
_outLD_ is expected to contain a list of SNPs for removal, which are later removed in line L385. It is created by a pairwise comparison of all the SNPs in each LD cluster separately, and appending a SNP with larger p-value to _outLD_. This means that the same SNP may appear more than once. When the _which_ in L385 meets this SNP for the first time, it attempts to find it, succeeds, returns the index, and the line returns the whole _final_ dataframe except for this SNP being removed, as expected.

![image](https://user-images.githubusercontent.com/5617740/112022590-bbc7ef00-8b32-11eb-822c-785ed9bbce33.png)

But when the same SNP is encountered in _outLD_ for the second time, _which_ cannot find this SNP in the _final_ dataframe anymore. Instead of returning an index, it returns a special object, _integer(0)_. L385 evaluates to _**final[-integer(0)]**_, which causes an empty dataframe to be returned and re-assigned to _final_ at line L385, removing all the SNPs (not only in the LD cluster - all the SNPs altogether!).

![image](https://user-images.githubusercontent.com/5617740/112022662-cc786500-8b32-11eb-9bf9-744c9808f630.png)

**The patch**
Using _unique_ leaves only one of each "SNP-trait" pair in _outLD_, and resolves the problem.